### PR TITLE
Fixed multiple definitions of Fail method on linking stage of build process

### DIFF
--- a/discordpp/rest-beast.hh
+++ b/discordpp/rest-beast.hh
@@ -32,14 +32,6 @@ namespace discordpp{
 	namespace ssl = boost::asio::ssl;       // from <boost/asio/ssl.hpp>
 	using tcp = boost::asio::ip::tcp;       // from <boost/asio/ip/tcp.hpp>
 
-	// Report a failure
-	void
-	fail(beast::error_code ec, char const *what){
-		if(std::string(what) != "shutdown" && ec.message() != "stream truncated"){
-			std::cerr << what << ": " << ec.message() << "\n";
-		}
-	}
-
 	// Performs an HTTP GET and prints the response
 	template<class BASE>
 	class RestBeast: public BASE, virtual public BotStruct, public std::enable_shared_from_this<RestBeast<BASE> >{
@@ -78,6 +70,14 @@ namespace discordpp{
 		http::request<http::string_body> req_;
 		std::unique_ptr<http::response<http::string_body>> res_;
 		std::unique_ptr<ssl::context> ctx_;
+		
+		// Report a failure
+		void
+		fail(beast::error_code ec, char const *what){
+			if(std::string(what) != "shutdown" && ec.message() != "stream truncated"){
+				std::cerr << what << ": " << ec.message() << "\n";
+			}
+		}
 
 		// Start the asynchronous operation
 		void runRest(


### PR DESCRIPTION
How to reproduce:

1. #include rest-beast in a header file (e.g header.h)
2. Include that header file in the respective .cpp file (#include header.h in header.cpp)
3. Include that header file in any class you want to get access to the methods of the header file. (#include header.h in main.cpp)
4. Build the project. 
5. The following error appears:

```
  /usr/bin/ld: CMakeFiles/league_projects.dir/src/BotManager.cpp.o: in function `boost::system::system_error::what() const':
/mnt/f/discordBotLearn/lolptProjects/lib/rest-beast/discordpp/rest-beast.hh:37: multiple definition of `discordpp::fail(boost::system::error_code, char const*)'; CMakeFiles/league_projects.dir/main.cc.o:/mnt/f/discordBotLearn/lolptProjects/lib/rest-beast/discordpp/rest-beast.hh:37: first defined here
collect2: error: ld returned 1 exit status 
```

This was tested on a clean Echo-bot template download. 


Solution:
1. Move the fail method into the rest-beast class, lowering its scope of action.