### PR TITLE
add support for arrays in on_read

### DIFF
--- a/discordpp/rest-beast.hh
+++ b/discordpp/rest-beast.hh
@@ -249,13 +249,15 @@ class RestBeast : public BASE,
                 *log << "Received: " << body << '\n';
             });
             if (!body.empty()) {
-                if (body.at(0) != '{') {
-                    std::cerr << "Discord replied:\n"
+                if (body.at(0) == '{') {
+                	jres = json::parse(body);
+                } else if (body.at(0) == '[') {
+                    jres = {{"body", json::parse(body)}};
+                } else {
+                	std::cerr << "Discord replied:\n"
                               << ss.str() << "\nTo the following target:\n"
                               << target << "\nWith the following payload:\n"
                               << payload << std::endl;
-                } else {
-                    jres = json::parse(body);
                 }
             }
         }


### PR DESCRIPTION
This is the proposed fix for issue #5 . It simply makes it so whenever an API endpoint returns a JSON array, it makes an object with the key "body" equal to that array value.